### PR TITLE
Link to Wiki/Issues/IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The aim of this project is to make MicroPython run on FPGAs using the [LiteX] & 
 ## Contact
 
  * [MicroPython on FPGA Mailing List](https://groups.google.com/forum/#!forum/upy-fpga/join)
- * [MicroPython on FPGA Chat Channel](irc://irc.freenode.net/#upy-fpga) ([WebChat](https://webchat.freenode.net/?channels=#upy-fpga))
+ * [MicroPython on FPGA Chat Channel, #upy-fpga on FreeNode](irc://irc.freenode.net/#upy-fpga) ([WebChat](https://webchat.freenode.net/?channels=#upy-fpga))
 
 ## Current Targets
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,15 @@
 
 The aim of this project is to make MicroPython run on FPGAs using the [LiteX] & [Migen+MiSoC] technologies. This allows you to do full stack development (FPGA gateware & soft CPU firmware) in Python!
 
+## More Information
+
+ * [Wiki](https://github.com/upy-fpga/issues-wiki/wiki)
+ * [GitHub Issues](https://github.com/upy-fpga/issues-wiki/issues)
+
 ## Contact
 
  * [MicroPython on FPGA Mailing List](https://groups.google.com/forum/#!forum/upy-fpga/join)
- * [MicroPython on FPGA Chat Channel]()
+ * [MicroPython on FPGA Chat Channel](irc://irc.freenode.net/#upy-fpga) ([WebChat](https://webchat.freenode.net/?channels=#upy-fpga))
 
 ## Current Targets
 


### PR DESCRIPTION
Added links to Wiki (which has more information), open Issues, and IRC channel.  (The irc:// link doesn't work in Markdown display, but maybe works in the upy-fpga.github.io view?)

Ewen